### PR TITLE
TISNEW-3605 validate if username exists in Profile database regardless of the case

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
   <groupId>uk.nhs.hee.tis</groupId>
   <artifactId>usermanagement</artifactId>
-  <version>0.0.35</version>
+  <version>0.0.36</version>
   <packaging>jar</packaging>
 
   <name>usermanagement</name>

--- a/src/main/java/uk/nhs/hee/tis/usermanagement/resource/UserManagementController.java
+++ b/src/main/java/uk/nhs/hee/tis/usermanagement/resource/UserManagementController.java
@@ -102,6 +102,13 @@ public class UserManagementController {
       throw new UserCreationException("Cannot create user, email address shouldn't contain white spaces");
     }
 
+    // validate if username exists in Profile/Auth database regardless of the case
+    Pageable pageable = PageRequest.of(0, 20); // set a default value to send the case insensitive query
+    Page<UserDTO> userDTOS = userManagementFacade.getAllUsers(pageable, user.getName());
+    if (userDTOS != null && userDTOS.hasContent()) {
+      throw new UserCreationException("Cannot create user, the username has already existed");
+    }
+
     userManagementFacade.publishUserCreationRequestedEvent(user);
     model.addAttribute("message", "A request for user " + user.getFirstName() + " " + user.getLastName() + " (" +
         user.getName() + ") has been made. It may take a little while before you'll be able to see the new user");


### PR DESCRIPTION
The usernames in Keycloak are all lower case. 
When we create a user with existing username, we would get a success page. But actually, it will fail, and will delete the record in Keycloak (because when some exception happens, it will delete the record in Keycoak which is designed for reverting creation), which causes a lot of inconsistency between Profile and Keycloak.

So add a validation to stop creating duplicates regardless of the case.