### PR TITLE
fix: remove KeyCloak secret

### DIFF
--- a/src/main/resources/application-local.properties
+++ b/src/main/resources/application-local.properties
@@ -1,7 +1,7 @@
-kc.realm: ${KC_REALM:lin}
-kc.master.realm: ${KC_MASTER_REALM:master}
-kc.client.id: ${KC_CLIENT_ID:admin-cli}
-kc.server.url: ${KC_SERVER_URL:https://dev-apps.tis.nhs.uk/auth}
-kc.username: ${KC_USERNAME:admin}
-kc.password: ${KC_PASSWORD:z3REi8nL8FiUT9Da7kGRmxMhf}
+kc.realm: ${KC_REALM:}
+kc.master.realm: ${KC_MASTER_REALM:}
+kc.client.id: ${KC_CLIENT_ID:}
+kc.server.url: ${KC_SERVER_URL:}
+kc.username: ${KC_USERNAME:}
+kc.password: ${KC_PASSWORD:}
 kc.timeout: ${KC_TIMEOUT:10000}


### PR DESCRIPTION
Application-local.properties contained KeyCloak credentials and they were not needed. This PR is to remove exposed credentials.

TISNEW-5214