### PR TITLE
chore: Add org.mockito mockito-core 2.22.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -24,6 +24,7 @@
     <java.version>1.8</java.version>
     <spring-cloud.version>Finchley.RC1</spring-cloud.version>
     <commons-lang.version>3.5</commons-lang.version>
+    <mockito.version>2.22.0</mockito.version>
 
     <!-- SonarCloud configuration -->
     <sonar.host.url>https://sonarcloud.io</sonar.host.url>
@@ -115,12 +116,6 @@
       <groupId>com.google.code.gson</groupId>
       <artifactId>gson</artifactId>
       <version>2.8.7</version>
-    </dependency>
-    <dependency>
-      <groupId>org.mockito</groupId>
-      <artifactId>mockito-core</artifactId>
-      <version>2.22.0</version>
-      <scope>test</scope>
     </dependency>
   </dependencies>
 


### PR DESCRIPTION
Running tests with Java 11 as per the new workflow causes troubles
with mocks. Adding a newer version of mockito-core should fix that.

TIS21-2116