### PR TITLE
chore(deps): bump tis-parent-client from 4.2.1 to 5.1.4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
   <groupId>uk.nhs.hee.tis</groupId>
   <artifactId>usermanagement</artifactId>
-  <version>0.0.39</version>
+  <version>0.0.40</version>
   <packaging>jar</packaging>
 
   <name>usermanagement</name>
@@ -65,7 +65,7 @@
     <dependency>
       <groupId>com.transformuk.hee</groupId>
       <artifactId>profile-client</artifactId>
-      <version>2.9.0</version>
+      <version>3.1.1</version>
     </dependency>
     <dependency>
       <groupId>com.transformuk.hee</groupId>


### PR DESCRIPTION
Bump the version of `tis-parent-client` to `5.1.4` to update transient
dependency `tis-security-jwt` to `5.1.4`, which allows usage with
Cognito/AWS API Gateway.

TIS21-2477, TIS21-2474