### PR TITLE
fix: non cognito environments

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
   <groupId>uk.nhs.hee.tis</groupId>
   <artifactId>usermanagement</artifactId>
-  <version>0.0.40</version>
+  <version>0.0.41</version>
   <packaging>jar</packaging>
 
   <name>usermanagement</name>
@@ -66,10 +66,6 @@
       <artifactId>spring-cloud-starter-netflix-hystrix</artifactId>
     </dependency>
 
-    <dependency>
-      <groupId>org.springframework.cloud</groupId>
-      <artifactId>spring-cloud-starter-aws</artifactId>
-    </dependency>
     <dependency>
       <groupId>com.amazonaws</groupId>
       <artifactId>aws-java-sdk-core</artifactId>

--- a/src/main/java/uk/nhs/hee/tis/usermanagement/config/CognitoAdminClientConfig.java
+++ b/src/main/java/uk/nhs/hee/tis/usermanagement/config/CognitoAdminClientConfig.java
@@ -2,6 +2,7 @@ package uk.nhs.hee.tis.usermanagement.config;
 
 import com.amazonaws.services.cognitoidp.AWSCognitoIdentityProvider;
 import com.amazonaws.services.cognitoidp.AWSCognitoIdentityProviderClientBuilder;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -9,6 +10,7 @@ import org.springframework.context.annotation.Configuration;
  * Configuration for Cognito.
  */
 @Configuration
+@ConditionalOnProperty(name = "application.authentication-provider", havingValue = "cognito")
 public class CognitoAdminClientConfig {
 
   /**

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -26,7 +26,3 @@ management.server.servlet.context-path=/actuator
 
 application.cache-evict-schedule=${CACHE_EVICT_CRON:0 0 * * * *}
 application.authentication-provider=keycloak
-
-# TODO: replace with better approach to disable AWS when not Cognito profile.
-cloud.aws.region.auto=false
-cloud.aws.region.static=eu-west-2


### PR DESCRIPTION
The Cognito configuration should be conditional on Cognito being the
authentication provider, as that is the only scenario where existence of
required env vars for AWS can be expected.

Remove AWS starter and related config as it is not used.

TIS21-2491