### PR TITLE
chore: fix task definitions pt 2

### DIFF
--- a/.aws/tis-usermanagement-nimdta.json
+++ b/.aws/tis-usermanagement-nimdta.json
@@ -3,7 +3,6 @@
     {
       "name": "tis-usermanagement",
       "image": "430723991443.dkr.ecr.eu-west-2.amazonaws.com/usermanagement:latest",
-      "executionRoleArn": "ecsTaskExecutionRole",
       "essential": true,
       "secrets": [
         {
@@ -101,6 +100,7 @@
   "requiresCompatibilities": [
     "FARGATE"
   ],
+  "executionRoleArn": "ecsTaskExecutionRole",
   "networkMode": "awsvpc",
   "cpu": "512",
   "memory": "1024"

--- a/.aws/tis-usermanagement-preprod.json
+++ b/.aws/tis-usermanagement-preprod.json
@@ -3,7 +3,6 @@
     {
       "name": "tis-usermanagement",
       "image": "430723991443.dkr.ecr.eu-west-2.amazonaws.com/usermanagement:latest",
-      "executionRoleArn": "ecsTaskExecutionRole",
       "essential": true,
       "secrets": [
         {
@@ -101,6 +100,7 @@
   "requiresCompatibilities": [
     "FARGATE"
   ],
+  "executionRoleArn": "ecsTaskExecutionRole",
   "networkMode": "awsvpc",
   "cpu": "512",
   "memory": "1024"

--- a/.aws/tis-usermanagement-prod.json
+++ b/.aws/tis-usermanagement-prod.json
@@ -3,7 +3,6 @@
     {
       "name": "tis-usermanagement",
       "image": "430723991443.dkr.ecr.eu-west-2.amazonaws.com/usermanagement:latest",
-      "executionRoleArn": "ecsTaskExecutionRole",
       "essential": true,
       "secrets": [
         {
@@ -101,6 +100,7 @@
   "requiresCompatibilities": [
     "FARGATE"
   ],
+  "executionRoleArn": "ecsTaskExecutionRole",
   "networkMode": "awsvpc",
   "cpu": "512",
   "memory": "1024"


### PR DESCRIPTION
The `executionRoleArn` is in the incorrect place in the definition file.

TIS21-2491