### PR TITLE
chore: add Cognito user pool env var to task defs

### DIFF
--- a/.aws/tis-usermanagement-nimdta.json
+++ b/.aws/tis-usermanagement-nimdta.json
@@ -66,6 +66,10 @@
           "valueFrom": "kc-timeout-usermanagement-nimdta"
         },
         {
+          "name": "COGNITO_USER_POOL_ID",
+          "valueFrom": "tis-cognito-pool-id-nimdta-v1"
+        },
+        {
           "name": "SPRING_PROFILES_ACTIVE",
           "valueFrom": "spring-profiles-active-usermanagement-nimdta"
         }

--- a/.aws/tis-usermanagement-preprod.json
+++ b/.aws/tis-usermanagement-preprod.json
@@ -66,6 +66,10 @@
           "valueFrom": "kc-timeout-usermanagement-preprod"
         },
         {
+          "name": "COGNITO_USER_POOL_ID",
+          "valueFrom": "tis-cognito-pool-id-preprod-v1"
+        },
+        {
           "name": "SPRING_PROFILES_ACTIVE",
           "valueFrom": "spring-profiles-active-usermanagement-preprod"
         }

--- a/.aws/tis-usermanagement-prod.json
+++ b/.aws/tis-usermanagement-prod.json
@@ -66,6 +66,10 @@
           "valueFrom": "kc-timeout-usermanagement-prod"
         },
         {
+          "name": "COGNITO_USER_POOL_ID",
+          "valueFrom": "tis-cognito-pool-id-prod-v1"
+        },
+        {
           "name": "SPRING_PROFILES_ACTIVE",
           "valueFrom": "spring-profiles-active-usermanagement-prod"
         }


### PR DESCRIPTION
Add the `COGNITO_USER_POOL_ID` environment variable to the AWS task
definitions, this will be used when the active Spring profiles include
`cognito`.

TIS21-2491