### PR TITLE
chore: add task roles to task definitions

### DIFF
--- a/.aws/tis-usermanagement-nimdta.json
+++ b/.aws/tis-usermanagement-nimdta.json
@@ -105,6 +105,7 @@
     "FARGATE"
   ],
   "executionRoleArn": "ecsTaskExecutionRole",
+  "taskRoleArn": "tis-nimdta-v1-user-admin-role",
   "networkMode": "awsvpc",
   "cpu": "512",
   "memory": "1024"

--- a/.aws/tis-usermanagement-preprod.json
+++ b/.aws/tis-usermanagement-preprod.json
@@ -105,6 +105,7 @@
     "FARGATE"
   ],
   "executionRoleArn": "ecsTaskExecutionRole",
+  "taskRoleArn": "tis-preprod-v1-user-admin-role",
   "networkMode": "awsvpc",
   "cpu": "512",
   "memory": "1024"

--- a/.aws/tis-usermanagement-prod.json
+++ b/.aws/tis-usermanagement-prod.json
@@ -105,6 +105,7 @@
     "FARGATE"
   ],
   "executionRoleArn": "ecsTaskExecutionRole",
+  "taskRoleArn": "tis-prod-v1-user-admin-role",
   "networkMode": "awsvpc",
   "cpu": "512",
   "memory": "1024"


### PR DESCRIPTION
The user management service lacks the permissions to access Cognito, add
the `user-admin` task roles to the task definitions for each
environment.

TIS21-2491