### PR TITLE
fix: no mapping for forwarding to allUsers.html

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
   <groupId>uk.nhs.hee.tis</groupId>
   <artifactId>usermanagement</artifactId>
-  <version>0.0.42</version>
+  <version>0.0.43</version>
   <packaging>jar</packaging>
 
   <name>usermanagement</name>

--- a/src/main/java/uk/nhs/hee/tis/usermanagement/config/WebConfig.java
+++ b/src/main/java/uk/nhs/hee/tis/usermanagement/config/WebConfig.java
@@ -15,7 +15,7 @@ public class WebConfig extends WebMvcConfigurerAdapter {
 
   @Override
   public void addViewControllers(ViewControllerRegistry registry) {
-    registry.addViewController("/").setViewName("forward:/allUsers.html");
+    registry.addViewController("/").setViewName("forward:/allUsers");
     registry.setOrder(Ordered.HIGHEST_PRECEDENCE);
     super.addViewControllers(registry);
   }


### PR DESCRIPTION
When logging in Usermanagement, a error page is shown as below:
![image](https://user-images.githubusercontent.com/33690649/168080897-a711939a-455e-4c8b-b9a7-1f7188f78818.png)
This is because the root path can't be redirected to the allUsers page correctly.


This fix has been tested on my local.

no-ticket