### PR TITLE
chore: bump profile version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
   <groupId>uk.nhs.hee.tis</groupId>
   <artifactId>usermanagement</artifactId>
-  <version>0.0.45</version>
+  <version>0.0.46</version>
   <packaging>jar</packaging>
 
   <name>usermanagement</name>
@@ -81,7 +81,7 @@
     <dependency>
       <groupId>com.transformuk.hee</groupId>
       <artifactId>profile-client</artifactId>
-      <version>3.1.1</version>
+      <version>3.2.0</version>
     </dependency>
     <dependency>
       <groupId>com.transformuk.hee</groupId>


### PR DESCRIPTION
This is required by an updated profile service.

NO-CARD: Blocks changes needed for moving Auth providers