### PR TITLE
chore(deps): declare and run on Java 11

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:8-alpine
+FROM eclipse-temurin:11-alpine
 
 EXPOSE 8100
 

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
   <groupId>uk.nhs.hee.tis</groupId>
   <artifactId>usermanagement</artifactId>
-  <version>0.0.46</version>
+  <version>0.0.47</version>
   <packaging>jar</packaging>
 
   <name>usermanagement</name>
@@ -21,7 +21,7 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-    <java.version>1.8</java.version>
+    <java.version>11</java.version>
     <spring-cloud.version>2021.0.1</spring-cloud.version>
     <mapstruct.version>1.5.5.Final</mapstruct.version>
     <aws-java-sdk.version>1.12.225</aws-java-sdk.version>


### PR DESCRIPTION
**Please review**.  Raised draft as I think it will need more testing with a fresher head!

This is required by an updated profile service, which is build Java 11. User Management was already built with Java 11 on the CI server.

NO-CARD: Blocks changes needed for moving Auth providers