### PR TITLE
fix: Require profile delete permission

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
   <groupId>uk.nhs.hee.tis</groupId>
   <artifactId>usermanagement</artifactId>
-  <version>0.0.51</version>
+  <version>0.0.52</version>
   <packaging>jar</packaging>
 
   <name>usermanagement</name>

--- a/src/main/java/uk/nhs/hee/tis/usermanagement/resource/UserResource.java
+++ b/src/main/java/uk/nhs/hee/tis/usermanagement/resource/UserResource.java
@@ -76,7 +76,7 @@ public class UserResource {
    * Gets a list of users, matching a search term if one is provided.
    *
    * @param pageable Definition of the page to return
-   * @param search Search term to search for in usernames
+   * @param search   Search term to search for in usernames
    * @return A collection of users which may be a page subset of the full results
    */
   @PreAuthorize("hasAuthority('heeuser:view')")
@@ -125,7 +125,7 @@ public class UserResource {
    * @return The {@link ResponseEntity} indicating the request has been accepted and should be
    *     deleted
    */
-  @PreAuthorize("hasAuthority('heeuser:delete')")
+  @PreAuthorize("hasAuthority('heeuser:delete') and hasAuthority('profile:delete:entities') ")
   @DeleteMapping("/{username}")
   ResponseEntity<UserDTO> deleteUser(@PathVariable String username) {
     userFacade.publishDeleteAuthenticationUserRequestedEvent(username);


### PR DESCRIPTION
This fixes a pre-existing gap.
Users may have permission to delete the AuthN user but not the profile. It also reduces the chance backend services containing conflicting data.

TIS21-6687: Angular UI for User Management