### PR TITLE
fix: set email_verified to true when creating a user

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
   <groupId>uk.nhs.hee.tis</groupId>
   <artifactId>usermanagement</artifactId>
-  <version>0.0.53</version>
+  <version>0.0.54</version>
   <packaging>jar</packaging>
 
   <name>usermanagement</name>

--- a/src/main/java/uk/nhs/hee/tis/usermanagement/service/CognitoAuthenticationAdminService.java
+++ b/src/main/java/uk/nhs/hee/tis/usermanagement/service/CognitoAuthenticationAdminService.java
@@ -10,6 +10,7 @@ import com.amazonaws.services.cognitoidp.model.AdminEnableUserRequest;
 import com.amazonaws.services.cognitoidp.model.AdminGetUserRequest;
 import com.amazonaws.services.cognitoidp.model.AdminGetUserResult;
 import com.amazonaws.services.cognitoidp.model.AdminUpdateUserAttributesRequest;
+import com.amazonaws.services.cognitoidp.model.AttributeType;
 import com.amazonaws.services.cognitoidp.model.UserNotFoundException;
 import java.util.Optional;
 import lombok.extern.slf4j.Slf4j;
@@ -33,6 +34,9 @@ import uk.nhs.hee.tis.usermanagement.mapper.CognitoResultMapper;
 public class CognitoAuthenticationAdminService extends AbstractAuthenticationAdminService {
 
   private static final String SERVICE_NAME = "cognito";
+
+  protected static final String EMAIL_VERIFIED_FIELD = "email_verified";
+  protected static final String EMAIL_VERIFIED_VALUE = "true";
 
   private final AWSCognitoIdentityProvider cognitoClient;
   private final String userPoolId;
@@ -62,7 +66,9 @@ public class CognitoAuthenticationAdminService extends AbstractAuthenticationAdm
   @Override
   AuthenticationUserDto createUser(CreateUserDTO createUserDto) {
     AdminCreateUserRequest request = requestMapper.toCreateUserRequest(createUserDto)
-        .withUserPoolId(userPoolId);
+        .withUserPoolId(userPoolId)
+        .withUserAttributes(
+            new AttributeType().withName(EMAIL_VERIFIED_FIELD).withValue(EMAIL_VERIFIED_VALUE));
 
     AdminCreateUserResult result = cognitoClient.adminCreateUser(request);
 

--- a/src/test/java/uk/nhs/hee/tis/usermanagement/service/CognitoAuthenticationAdminServiceTest.java
+++ b/src/test/java/uk/nhs/hee/tis/usermanagement/service/CognitoAuthenticationAdminServiceTest.java
@@ -10,6 +10,8 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static uk.nhs.hee.tis.usermanagement.service.CognitoAuthenticationAdminService.EMAIL_VERIFIED_FIELD;
+import static uk.nhs.hee.tis.usermanagement.service.CognitoAuthenticationAdminService.EMAIL_VERIFIED_VALUE;
 
 import com.amazonaws.services.cognitoidp.AWSCognitoIdentityProviderClient;
 import com.amazonaws.services.cognitoidp.model.AWSCognitoIdentityProviderException;
@@ -109,7 +111,7 @@ public class CognitoAuthenticationAdminServiceTest {
     assertThat("Unexpected password.", request.getTemporaryPassword(), nullValue());
 
     List<AttributeType> attributes = request.getUserAttributes();
-    assertThat("Unexpected attribute count.", attributes.size(), is(3));
+    assertThat("Unexpected attribute count.", attributes.size(), is(4));
 
     Map<String, String> attributeMap = attributes.stream()
         .collect(Collectors.toMap(AttributeType::getName, AttributeType::getValue));
@@ -117,6 +119,8 @@ public class CognitoAuthenticationAdminServiceTest {
     assertThat("Unexpected given name.", attributeMap.get(GIVEN_NAME_FIELD), is(GIVEN_NAME_VALUE));
     assertThat("Unexpected family name.", attributeMap.get(FAMILY_NAME_FIELD),
         is(FAMILY_NAME_VALUE));
+    assertThat("Unexpected email verified.", attributeMap.get(EMAIL_VERIFIED_FIELD),
+        is(EMAIL_VERIFIED_VALUE));
   }
 
   @Test


### PR DESCRIPTION
After the account is created by admin API, status of the account is FORCE_CHANGE_PASSWORD and no verification code is sent, so we have to set `email_verified` to true in the code.

Context is here: https://hee-nhs-tis.slack.com/archives/C082EDEBMD3/p1733763023068209?thread_ts=1733760597.510279&cid=C082EDEBMD3


This fix has been tested locally with tis-local-v1 user pool.


Cognito switchover