### PR TITLE
fix: catch bad IDP GetUser requests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
   <groupId>uk.nhs.hee.tis</groupId>
   <artifactId>usermanagement</artifactId>
-  <version>0.0.55</version>
+  <version>0.0.56</version>
   <packaging>jar</packaging>
 
   <name>usermanagement</name>

--- a/src/main/java/uk/nhs/hee/tis/usermanagement/service/CognitoAuthenticationAdminService.java
+++ b/src/main/java/uk/nhs/hee/tis/usermanagement/service/CognitoAuthenticationAdminService.java
@@ -11,6 +11,7 @@ import com.amazonaws.services.cognitoidp.model.AdminGetUserRequest;
 import com.amazonaws.services.cognitoidp.model.AdminGetUserResult;
 import com.amazonaws.services.cognitoidp.model.AdminUpdateUserAttributesRequest;
 import com.amazonaws.services.cognitoidp.model.AttributeType;
+import com.amazonaws.services.cognitoidp.model.InvalidParameterException;
 import com.amazonaws.services.cognitoidp.model.UserNotFoundException;
 import java.util.Optional;
 import lombok.extern.slf4j.Slf4j;
@@ -92,8 +93,8 @@ public class CognitoAuthenticationAdminService extends AbstractAuthenticationAdm
     try {
       AdminGetUserResult result = cognitoClient.adminGetUser(request);
       return Optional.of(resultMapper.toAuthenticationUser(result));
-    } catch (UserNotFoundException e) {
-      log.info(e.getMessage());
+    } catch (InvalidParameterException | UserNotFoundException e) {
+      log.info(e.getMessage(), e);
       return Optional.empty();
     }
   }


### PR DESCRIPTION
We are finding that searches error due to bad profile data.

**N.B.**: The Facade which calls this could filter for username patterns and create a cleaner execution flow.  I have not verified if this still makes a request to Cognito, therefore incurring the associated cost, and this is only a second one of the 10s of `AWSCognitoIdentityProviderException`s.
This parent class however contains server & communication exceptions which might present a wider issue.  I am avoiding addressing or re-evaluating whether it would be worse to catch all of those exceptions and confuse "no auth user" & "auth search error" states for application data.

chore: use JUnit5

NO-CARD: Understanding the problem