### PR TITLE
fix: bump version for profile-client

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
   <groupId>uk.nhs.hee.tis</groupId>
   <artifactId>usermanagement</artifactId>
-  <version>0.0.56</version>
+  <version>0.0.57</version>
   <packaging>jar</packaging>
 
   <name>usermanagement</name>
@@ -81,7 +81,7 @@
     <dependency>
       <groupId>com.transformuk.hee</groupId>
       <artifactId>profile-client</artifactId>
-      <version>3.3.0</version>
+      <version>3.4.0</version>
     </dependency>
     <dependency>
       <groupId>com.transformuk.hee</groupId>


### PR DESCRIPTION
Otherwise the permission type "POST" cannot be recognised.

depends on https://github.com/Health-Education-England/TIS-PROFILE/pull/306/files

TIS21-7021