### PR TITLE
feat: admin reset MFA for user

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
   <groupId>uk.nhs.hee.tis</groupId>
   <artifactId>usermanagement</artifactId>
-  <version>0.0.61</version>
+  <version>0.1.0</version>
   <packaging>jar</packaging>
 
   <name>usermanagement</name>

--- a/src/main/java/uk/nhs/hee/tis/usermanagement/DTOs/AuthenticationUserDto.java
+++ b/src/main/java/uk/nhs/hee/tis/usermanagement/DTOs/AuthenticationUserDto.java
@@ -20,4 +20,6 @@ public class AuthenticationUserDto {
   private Map<String, List<String>> attributes = new HashMap<>();
   private String password;
   private Boolean temporaryPassword;
+  private List<String> userMFASettingList;
+  private String preferredMfaSetting;
 }

--- a/src/main/java/uk/nhs/hee/tis/usermanagement/DTOs/AuthenticationUserDto.java
+++ b/src/main/java/uk/nhs/hee/tis/usermanagement/DTOs/AuthenticationUserDto.java
@@ -20,6 +20,6 @@ public class AuthenticationUserDto {
   private Map<String, List<String>> attributes = new HashMap<>();
   private String password;
   private Boolean temporaryPassword;
-  private List<String> userMFASettingList;
+  private List<String> userMfaSettingList;
   private String preferredMfaSetting;
 }

--- a/src/main/java/uk/nhs/hee/tis/usermanagement/DTOs/UserDTO.java
+++ b/src/main/java/uk/nhs/hee/tis/usermanagement/DTOs/UserDTO.java
@@ -5,6 +5,9 @@ import java.util.List;
 import java.util.Set;
 import lombok.Data;
 
+/**
+ * Data Transfer Object for User details.
+ */
 @Data
 public class UserDTO {
 
@@ -20,6 +23,6 @@ public class UserDTO {
   private Set<String> localOffices = new HashSet<>();
   private Set<String> associatedTrusts = new HashSet<>();
   private Set<String> associatedProgrammes = new HashSet<>();
-  private List<String> userMFASettingList;
+  private List<String> userMfaSettingList;
   private String preferredMfaSetting;
 }

--- a/src/main/java/uk/nhs/hee/tis/usermanagement/DTOs/UserDTO.java
+++ b/src/main/java/uk/nhs/hee/tis/usermanagement/DTOs/UserDTO.java
@@ -1,8 +1,11 @@
 package uk.nhs.hee.tis.usermanagement.DTOs;
 
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
+import lombok.Data;
 
+@Data
 public class UserDTO {
 
   private String authId;
@@ -17,100 +20,6 @@ public class UserDTO {
   private Set<String> localOffices = new HashSet<>();
   private Set<String> associatedTrusts = new HashSet<>();
   private Set<String> associatedProgrammes = new HashSet<>();
-
-  public String getAuthId() {
-    return authId;
-  }
-
-  public void setAuthId(String authId) {
-    this.authId = authId;
-  }
-
-  public String getName() {
-    return name;
-  }
-
-  public void setName(String name) {
-    this.name = name;
-  }
-
-  public String getFirstName() {
-    return firstName;
-  }
-
-  public void setFirstName(String firstName) {
-    this.firstName = firstName;
-  }
-
-  public String getLastName() {
-    return lastName;
-  }
-
-  public void setLastName(String lastName) {
-    this.lastName = lastName;
-  }
-
-  public String getGmcId() {
-    return gmcId;
-  }
-
-  public void setGmcId(String gmcId) {
-    this.gmcId = gmcId;
-  }
-
-  public String getPhoneNumber() {
-    return phoneNumber;
-  }
-
-  public void setPhoneNumber(String phoneNumber) {
-    this.phoneNumber = phoneNumber;
-  }
-
-  public String getEmailAddress() {
-    return emailAddress;
-  }
-
-  public void setEmailAddress(String emailAddress) {
-    this.emailAddress = emailAddress;
-  }
-
-  public boolean getActive() {
-    return active;
-  }
-
-  public void setActive(boolean active) {
-    this.active = active;
-  }
-
-  public Set<String> getRoles() {
-    return roles;
-  }
-
-  public void setRoles(Set<String> roles) {
-    this.roles = roles;
-  }
-
-  public Set<String> getLocalOffices() {
-    return localOffices;
-  }
-
-  public void setLocalOffices(Set<String> localOffices) {
-    this.localOffices = localOffices;
-  }
-
-  public Set<String> getAssociatedTrusts() {
-    return associatedTrusts;
-  }
-
-  public void setAssociatedTrusts(Set<String> associatedTrusts) {
-    this.associatedTrusts = associatedTrusts;
-  }
-
-  public Set<String> getAssociatedProgrammes() {
-    return associatedProgrammes;
-  }
-
-  public void setAssociatedProgrammes(Set<String> associatedProgrammes) {
-    this.associatedProgrammes = associatedProgrammes;
-  }
+  private List<String> userMFASettingList;
+  private String preferredMfaSetting;
 }

--- a/src/main/java/uk/nhs/hee/tis/usermanagement/facade/UserManagementFacade.java
+++ b/src/main/java/uk/nhs/hee/tis/usermanagement/facade/UserManagementFacade.java
@@ -81,7 +81,7 @@ public class UserManagementFacade {
 
   public UserDTO getCompleteUser(String username) {
     Optional<HeeUserDTO> optionalHeeUserDTO = profileService.getUserByUsername(username);
-    Optional<AuthenticationUserDto> optionalAuthenticationUser = authenticationAdminService.getUser(
+    Optional<AuthenticationUserDto> optionalAuthenticationUser = authenticationAdminService.getUserWithMfaInfo(
         username);
 
     HeeUserDTO heeUserDTO = optionalHeeUserDTO.orElseThrow(
@@ -97,6 +97,10 @@ public class UserManagementFacade {
     }
 
     return heeUserMapper.convert(heeUserDTO, authenticationUser);
+  }
+
+  public void resetUserMfaSettings(String username) {
+    authenticationAdminService.resetUserMfaSettings(username);
   }
 
   public UserDTO getUserByNameIgnoreCase(String username) {

--- a/src/main/java/uk/nhs/hee/tis/usermanagement/facade/UserManagementFacade.java
+++ b/src/main/java/uk/nhs/hee/tis/usermanagement/facade/UserManagementFacade.java
@@ -81,8 +81,8 @@ public class UserManagementFacade {
 
   public UserDTO getCompleteUser(String username) {
     Optional<HeeUserDTO> optionalHeeUserDTO = profileService.getUserByUsername(username);
-    Optional<AuthenticationUserDto> optionalAuthenticationUser = authenticationAdminService.getUserWithMfaInfo(
-        username);
+    Optional<AuthenticationUserDto> optionalAuthenticationUser =
+        authenticationAdminService.getUserWithMfaInfo(username);
 
     HeeUserDTO heeUserDTO = optionalHeeUserDTO.orElseThrow(
         () -> new UserNotFoundException(username, ProfileService.NAME));
@@ -99,6 +99,11 @@ public class UserManagementFacade {
     return heeUserMapper.convert(heeUserDTO, authenticationUser);
   }
 
+  /**
+   * Reset the MFA settings for a user.
+   *
+   * @param username the username to reset MFA settings for
+   */
   public void resetUserMfaSettings(String username) {
     authenticationAdminService.resetUserMfaSettings(username);
   }

--- a/src/main/java/uk/nhs/hee/tis/usermanagement/mapper/CognitoResultMapper.java
+++ b/src/main/java/uk/nhs/hee/tis/usermanagement/mapper/CognitoResultMapper.java
@@ -8,6 +8,7 @@ import org.mapstruct.AfterMapping;
 import org.mapstruct.Mapping;
 import org.mapstruct.MappingTarget;
 import software.amazon.awssdk.services.cognitoidentityprovider.model.AdminCreateUserResponse;
+import software.amazon.awssdk.services.cognitoidentityprovider.model.AdminGetUserResponse;
 import software.amazon.awssdk.services.cognitoidentityprovider.model.AttributeType;
 import software.amazon.awssdk.services.cognitoidentityprovider.model.AuthEventType;
 import software.amazon.awssdk.services.cognitoidentityprovider.model.ChallengeResponseType;
@@ -65,6 +66,15 @@ public abstract class CognitoResultMapper {
    * @return the converted authentication user.
    */
   public abstract AuthenticationUserDto toAuthenticationUser(UserType user);
+
+  /**
+   * Convert a cognito admin-get-user result to an authentication user.
+   *
+   * @param cognitoResult the Cognito result to convert.
+   * @return The converted authentication user.
+   */
+  @Mapping(target = "attributes", source = "userAttributes")
+  public abstract AuthenticationUserDto toAuthenticationUser(AdminGetUserResponse cognitoResult);
 
   /**
    * Convert a list of Cognito {@link AttributeType} to a generic map.

--- a/src/main/java/uk/nhs/hee/tis/usermanagement/mapper/CognitoResultMapperImpl.java
+++ b/src/main/java/uk/nhs/hee/tis/usermanagement/mapper/CognitoResultMapperImpl.java
@@ -115,7 +115,7 @@ public class CognitoResultMapperImpl extends CognitoResultMapper {
     extractAttributes(authenticationUserDto);
 
     if (cognitoResult.hasUserMFASettingList()) {
-      authenticationUserDto.setUserMFASettingList(cognitoResult.userMFASettingList());
+      authenticationUserDto.setUserMfaSettingList(cognitoResult.userMFASettingList());
     }
     authenticationUserDto.setPreferredMfaSetting(cognitoResult.preferredMfaSetting());
 

--- a/src/main/java/uk/nhs/hee/tis/usermanagement/mapper/CognitoResultMapperImpl.java
+++ b/src/main/java/uk/nhs/hee/tis/usermanagement/mapper/CognitoResultMapperImpl.java
@@ -5,6 +5,7 @@ import java.util.Date;
 import java.util.List;
 import org.springframework.stereotype.Component;
 import software.amazon.awssdk.services.cognitoidentityprovider.model.AdminCreateUserResponse;
+import software.amazon.awssdk.services.cognitoidentityprovider.model.AdminGetUserResponse;
 import software.amazon.awssdk.services.cognitoidentityprovider.model.AttributeType;
 import software.amazon.awssdk.services.cognitoidentityprovider.model.AuthEventType;
 import software.amazon.awssdk.services.cognitoidentityprovider.model.EventContextDataType;
@@ -94,6 +95,29 @@ public class CognitoResultMapperImpl extends CognitoResultMapper {
     authenticationUserDto.setAttributes(convertAttributes(user.attributes()));
 
     extractAttributes(authenticationUserDto);
+
+    return authenticationUserDto;
+  }
+
+  @Override
+  public AuthenticationUserDto toAuthenticationUser(AdminGetUserResponse cognitoResult) {
+    if (cognitoResult == null) {
+      return null;
+    }
+
+    AuthenticationUserDto authenticationUserDto = new AuthenticationUserDto();
+    authenticationUserDto.setUsername(cognitoResult.username());
+    if (cognitoResult.enabled() != null) {
+      authenticationUserDto.setEnabled(cognitoResult.enabled());
+    }
+    authenticationUserDto.setAttributes(convertAttributes(cognitoResult.userAttributes()));
+
+    extractAttributes(authenticationUserDto);
+
+    if (cognitoResult.hasUserMFASettingList()) {
+      authenticationUserDto.setUserMFASettingList(cognitoResult.userMFASettingList());
+    }
+    authenticationUserDto.setPreferredMfaSetting(cognitoResult.preferredMfaSetting());
 
     return authenticationUserDto;
   }

--- a/src/main/java/uk/nhs/hee/tis/usermanagement/mapper/HeeUserMapper.java
+++ b/src/main/java/uk/nhs/hee/tis/usermanagement/mapper/HeeUserMapper.java
@@ -180,7 +180,7 @@ public class HeeUserMapper {
       userDto.setAuthId(authenticationUserDto.getId());
       userDto.setActive(authenticationUserDto.isEnabled());
       userDto.setPreferredMfaSetting(authenticationUserDto.getPreferredMfaSetting());
-      userDto.setUserMFASettingList(authenticationUserDto.getUserMFASettingList());
+      userDto.setUserMfaSettingList(authenticationUserDto.getUserMfaSettingList());
     }
     return userDto;
   }

--- a/src/main/java/uk/nhs/hee/tis/usermanagement/mapper/HeeUserMapper.java
+++ b/src/main/java/uk/nhs/hee/tis/usermanagement/mapper/HeeUserMapper.java
@@ -42,7 +42,7 @@ public class HeeUserMapper {
     Preconditions.checkNotNull(userDto, "stop being stooopid");
     return mapUserAttributes(userDto.getName(), userDto.getFirstName(), userDto.getLastName(),
         userDto.getGmcId(),
-        userDto.getPhoneNumber(), userDto.getEmailAddress(), userDto.getActive(),
+        userDto.getPhoneNumber(), userDto.getEmailAddress(), userDto.isActive(),
         userDto.getLocalOffices(),
         userDto.getRoles(), userDto.getAssociatedTrusts(), userDto.getAssociatedProgrammes(),
         knownTrusts, knownProgrammes);
@@ -179,6 +179,8 @@ public class HeeUserMapper {
     if (authenticationUserDto != null) {
       userDto.setAuthId(authenticationUserDto.getId());
       userDto.setActive(authenticationUserDto.isEnabled());
+      userDto.setPreferredMfaSetting(authenticationUserDto.getPreferredMfaSetting());
+      userDto.setUserMFASettingList(authenticationUserDto.getUserMFASettingList());
     }
     return userDto;
   }

--- a/src/main/java/uk/nhs/hee/tis/usermanagement/resource/UserResource.java
+++ b/src/main/java/uk/nhs/hee/tis/usermanagement/resource/UserResource.java
@@ -86,6 +86,18 @@ public class UserResource {
   }
 
   /**
+   * Resets a user's MFA settings, removing any configured settings so they can be reconfigured on
+   * next login.
+   *
+   * @param username The name of the user to reset MFA settings for
+   */
+  @PreAuthorize("hasAuthority('heeuser:add:modify')")
+  @PostMapping("/{username}/mfa/reset")
+  public void resetUserMfaSettings(@PathVariable String username) {
+    userFacade.resetUserMfaSettings(username);
+  }
+
+  /**
    * Gets a list of users, matching a search term if one is provided.
    *
    * @param pageable Definition of the page to return

--- a/src/main/java/uk/nhs/hee/tis/usermanagement/service/AuthenticationAdminService.java
+++ b/src/main/java/uk/nhs/hee/tis/usermanagement/service/AuthenticationAdminService.java
@@ -27,6 +27,20 @@ public interface AuthenticationAdminService {
   Optional<AuthenticationUserDto> getUser(String username);
 
   /**
+   * Get the user from the authentication provider for the given username, including MFA info.
+   *
+   * @param username The username to get the user for.
+   * @return An optional user, empty if not found.
+   */
+  Optional<AuthenticationUserDto> getUserWithMfaInfo(String username);
+
+  /**
+   * Reset the user's MFA settings in the authentication provider.
+   *
+   * @param username The username to reset the MFA settings for.
+   */
+  void resetUserMfaSettings(String username);
+  /**
    * Update the user in the authentication provider.
    *
    * @param authenticationUser The user details to update.

--- a/src/main/java/uk/nhs/hee/tis/usermanagement/service/KeyCloakAdminClientService.java
+++ b/src/main/java/uk/nhs/hee/tis/usermanagement/service/KeyCloakAdminClientService.java
@@ -155,7 +155,7 @@ public class KeyCloakAdminClientService extends AbstractAuthenticationAdminServi
     attributes.put("DBC", dbcs);
     return User.create(userDTO.getAuthId(), userDTO.getFirstName(), userDTO.getLastName(),
         userDTO.getName(),
-        userDTO.getEmailAddress(), null, null, attributes, userDTO.getActive());
+        userDTO.getEmailAddress(), null, null, attributes, userDTO.isActive());
   }
 
   private User heeUserToKeycloakUser(CreateUserDTO createUserDTO) {
@@ -176,6 +176,16 @@ public class KeyCloakAdminClientService extends AbstractAuthenticationAdminServi
 
   @Override
   public List<UserAuthEventDto> getUserAuthEvents(String username) {
+    throw new NotImplementedException();
+  }
+
+  @Override
+  public Optional<AuthenticationUserDto> getUserWithMfaInfo(String username) {
+    throw new NotImplementedException();
+  }
+
+  @Override
+  public void resetUserMfaSettings(String username) {
     throw new NotImplementedException();
   }
 }

--- a/src/test/java/uk/nhs/hee/tis/usermanagement/facade/UserManagementFacadeTest.java
+++ b/src/test/java/uk/nhs/hee/tis/usermanagement/facade/UserManagementFacadeTest.java
@@ -175,7 +175,7 @@ class UserManagementFacadeTest {
     authenticationUser.setId("userId1");
     authenticationUser.setEnabled(true);
     List<String> mfaSettings = Arrays.asList("EMAIL_OTP", "SOFTWARE_TOKEN_MFA");
-    authenticationUser.setUserMFASettingList(mfaSettings);
+    authenticationUser.setUserMfaSettingList(mfaSettings);
 
     when(profileService.getUserByUsername(USERNAME)).thenReturn(Optional.of(heeUser));
     when(authenticationAdminService.getUserWithMfaInfo(USERNAME)).thenReturn(
@@ -188,7 +188,7 @@ class UserManagementFacadeTest {
     assertThat("Unexpected user enabled flag.", user.isActive(), is(true));
     assertThat("Unexpected size of roles.", user.getRoles().size(), is(1));
     assertThat("Unexpected roles.", user.getRoles().iterator().next(), is(assignableRole));
-    assertThat("Unexpected mfa settings", user.getUserMFASettingList(), is(mfaSettings));
+    assertThat("Unexpected mfa settings", user.getUserMfaSettingList(), is(mfaSettings));
   }
 
   @ParameterizedTest

--- a/src/test/java/uk/nhs/hee/tis/usermanagement/facade/UserManagementFacadeTest.java
+++ b/src/test/java/uk/nhs/hee/tis/usermanagement/facade/UserManagementFacadeTest.java
@@ -455,6 +455,13 @@ class UserManagementFacadeTest {
     Assertions.assertNotNull(password);
   }
 
+  @Test
+  void shouldResetUserMfaSettings() {
+    testClass.resetUserMfaSettings(USERNAME);
+
+    verify(authenticationAdminService).resetUserMfaSettings(USERNAME);
+  }
+
   /**
    * Create a set of roles with the given names.
    *

--- a/src/test/java/uk/nhs/hee/tis/usermanagement/mapper/CognitoResultMapperTest.java
+++ b/src/test/java/uk/nhs/hee/tis/usermanagement/mapper/CognitoResultMapperTest.java
@@ -1,6 +1,7 @@
 package uk.nhs.hee.tis.usermanagement.mapper;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 import java.util.Arrays;
 import java.util.List;
@@ -89,7 +90,7 @@ class CognitoResultMapperTest {
   }
 
   @Test
-  void shouldMapAdminGetUserResponseToAuthenticationUser() {
+  void shouldMapAdminGetUserResponseToAuthenticationUserWithMfaSettings() {
     AdminGetUserResponse adminGetUserResponse = AdminGetUserResponse.builder()
         .username(EMAIL)
         .userAttributes(
@@ -124,5 +125,41 @@ class CognitoResultMapperTest {
     assertEquals(EMAIL, userDto.getAttributes().get(ATTR_NAME_EMAIL).get(0));
     assertEquals(PREFERRED_MFA, userDto.getPreferredMfaSetting());
     assertEquals(MFA_SETTINGS, userDto.getUserMfaSettingList());
+  }
+
+  @Test
+  void shouldMapAdminGetUserResponseToAuthenticationUserWithoutMfaSettings() {
+    AdminGetUserResponse adminGetUserResponse = AdminGetUserResponse.builder()
+        .username(EMAIL)
+        .userAttributes(
+            AttributeType.builder().name(ATTR_NAME_SUB).value(SUB).build(),
+            AttributeType.builder().name(ATTR_NAME_GIVEN_NAME).value(GIVEN_NAME).build(),
+            AttributeType.builder().name(ATTR_NAME_FAMILY_NAME).value(FAMILY_NAME).build(),
+            AttributeType.builder().name(ATTR_NAME_EMAIL).value(EMAIL).build(),
+            AttributeType.builder().name(ATTR_EMAIL_VERIFIED).value(EMAIL_VERIFIED).build(),
+            AttributeType.builder().name(ATTR_NAME_PREFERRED_USERNAME)
+                .value(PREFERRED_USERNAME).build()
+        )
+        .enabled(ENABLED)
+        .build();
+
+    AuthenticationUserDto userDto = mapper.toAuthenticationUser(adminGetUserResponse);
+
+    assertEquals(SUB, userDto.getId());
+    assertEquals(EMAIL, userDto.getUsername());
+    assertEquals(GIVEN_NAME, userDto.getGivenName());
+    assertEquals(FAMILY_NAME, userDto.getFamilyName());
+    assertEquals(EMAIL, userDto.getEmail());
+    assertEquals(ENABLED, userDto.isEnabled());
+    assertEquals(6, userDto.getAttributes().size());
+    assertEquals(SUB, userDto.getAttributes().get(ATTR_NAME_SUB).get(0));
+    assertEquals(EMAIL_VERIFIED, userDto.getAttributes().get(ATTR_EMAIL_VERIFIED).get(0));
+    assertEquals(PREFERRED_USERNAME,
+        userDto.getAttributes().get(ATTR_NAME_PREFERRED_USERNAME).get(0));
+    assertEquals(GIVEN_NAME, userDto.getAttributes().get(ATTR_NAME_GIVEN_NAME).get(0));
+    assertEquals(FAMILY_NAME, userDto.getAttributes().get(ATTR_NAME_FAMILY_NAME).get(0));
+    assertEquals(EMAIL, userDto.getAttributes().get(ATTR_NAME_EMAIL).get(0));
+    assertNull(userDto.getPreferredMfaSetting());
+    assertNull(userDto.getUserMfaSettingList());
   }
 }

--- a/src/test/java/uk/nhs/hee/tis/usermanagement/mapper/CognitoResultMapperTest.java
+++ b/src/test/java/uk/nhs/hee/tis/usermanagement/mapper/CognitoResultMapperTest.java
@@ -123,6 +123,6 @@ class CognitoResultMapperTest {
     assertEquals(FAMILY_NAME, userDto.getAttributes().get(ATTR_NAME_FAMILY_NAME).get(0));
     assertEquals(EMAIL, userDto.getAttributes().get(ATTR_NAME_EMAIL).get(0));
     assertEquals(PREFERRED_MFA, userDto.getPreferredMfaSetting());
-    assertEquals(MFA_SETTINGS, userDto.getUserMFASettingList());
+    assertEquals(MFA_SETTINGS, userDto.getUserMfaSettingList());
   }
 }

--- a/src/test/java/uk/nhs/hee/tis/usermanagement/mapper/CognitoResultMapperTest.java
+++ b/src/test/java/uk/nhs/hee/tis/usermanagement/mapper/CognitoResultMapperTest.java
@@ -2,9 +2,11 @@ package uk.nhs.hee.tis.usermanagement.mapper;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+import java.util.Arrays;
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import software.amazon.awssdk.services.cognitoidentityprovider.model.AdminGetUserResponse;
 import software.amazon.awssdk.services.cognitoidentityprovider.model.AttributeType;
 import software.amazon.awssdk.services.cognitoidentityprovider.model.UserType;
 import uk.nhs.hee.tis.usermanagement.DTOs.AuthenticationUserDto;
@@ -25,6 +27,8 @@ class CognitoResultMapperTest {
   private static final String GIVEN_NAME = "Anthony";
   private static final String FAMILY_NAME = "Gilliam";
   private static final String EMAIL = "anthony.gilliam@dummy.com";
+  private static final String PREFERRED_MFA = "SOFTWARE_TOKEN_MFA";
+  private static final List<String> MFA_SETTINGS = Arrays.asList("EMAIL_OTP", "SOFTWARE_TOKEN_MFA");
 
   private CognitoResultMapper mapper;
 
@@ -82,5 +86,43 @@ class CognitoResultMapperTest {
     assertEquals(GIVEN_NAME, userDto.getAttributes().get(ATTR_NAME_GIVEN_NAME).get(0));
     assertEquals(FAMILY_NAME, userDto.getAttributes().get(ATTR_NAME_FAMILY_NAME).get(0));
     assertEquals(EMAIL, userDto.getAttributes().get(ATTR_NAME_EMAIL).get(0));
+  }
+
+  @Test
+  void shouldMapAdminGetUserResponseToAuthenticationUser() {
+    AdminGetUserResponse adminGetUserResponse = AdminGetUserResponse.builder()
+        .username(EMAIL)
+        .userAttributes(
+            AttributeType.builder().name(ATTR_NAME_SUB).value(SUB).build(),
+            AttributeType.builder().name(ATTR_NAME_GIVEN_NAME).value(GIVEN_NAME).build(),
+            AttributeType.builder().name(ATTR_NAME_FAMILY_NAME).value(FAMILY_NAME).build(),
+            AttributeType.builder().name(ATTR_NAME_EMAIL).value(EMAIL).build(),
+            AttributeType.builder().name(ATTR_EMAIL_VERIFIED).value(EMAIL_VERIFIED).build(),
+            AttributeType.builder().name(ATTR_NAME_PREFERRED_USERNAME)
+                .value(PREFERRED_USERNAME).build()
+        )
+        .userMFASettingList(MFA_SETTINGS)
+        .preferredMfaSetting(PREFERRED_MFA)
+        .enabled(ENABLED)
+        .build();
+
+    AuthenticationUserDto userDto = mapper.toAuthenticationUser(adminGetUserResponse);
+
+    assertEquals(SUB, userDto.getId());
+    assertEquals(EMAIL, userDto.getUsername());
+    assertEquals(GIVEN_NAME, userDto.getGivenName());
+    assertEquals(FAMILY_NAME, userDto.getFamilyName());
+    assertEquals(EMAIL, userDto.getEmail());
+    assertEquals(ENABLED, userDto.isEnabled());
+    assertEquals(6, userDto.getAttributes().size());
+    assertEquals(SUB, userDto.getAttributes().get(ATTR_NAME_SUB).get(0));
+    assertEquals(EMAIL_VERIFIED, userDto.getAttributes().get(ATTR_EMAIL_VERIFIED).get(0));
+    assertEquals(PREFERRED_USERNAME,
+        userDto.getAttributes().get(ATTR_NAME_PREFERRED_USERNAME).get(0));
+    assertEquals(GIVEN_NAME, userDto.getAttributes().get(ATTR_NAME_GIVEN_NAME).get(0));
+    assertEquals(FAMILY_NAME, userDto.getAttributes().get(ATTR_NAME_FAMILY_NAME).get(0));
+    assertEquals(EMAIL, userDto.getAttributes().get(ATTR_NAME_EMAIL).get(0));
+    assertEquals(PREFERRED_MFA, userDto.getPreferredMfaSetting());
+    assertEquals(MFA_SETTINGS, userDto.getUserMFASettingList());
   }
 }

--- a/src/test/java/uk/nhs/hee/tis/usermanagement/mapper/HeeUserMapperTest.java
+++ b/src/test/java/uk/nhs/hee/tis/usermanagement/mapper/HeeUserMapperTest.java
@@ -70,7 +70,7 @@ class HeeUserMapperTest {
     authUser.setId(SUB);
     authUser.setEnabled(true);
     authUser.setPreferredMfaSetting(PREFERRED_MFA);
-    authUser.setUserMFASettingList(MFA_SETTINGS);
+    authUser.setUserMfaSettingList(MFA_SETTINGS);
 
     // when
     UserDTO result = heeUserMapper.convert(heeUser, authUser);
@@ -91,7 +91,7 @@ class HeeUserMapperTest {
     assertEquals(SUB, result.getAuthId());
     assertTrue(result.isActive());
     assertEquals(PREFERRED_MFA, result.getPreferredMfaSetting());
-    assertEquals(MFA_SETTINGS, result.getUserMFASettingList());
+    assertEquals(MFA_SETTINGS, result.getUserMfaSettingList());
   }
 
   @Test

--- a/src/test/java/uk/nhs/hee/tis/usermanagement/mapper/HeeUserMapperTest.java
+++ b/src/test/java/uk/nhs/hee/tis/usermanagement/mapper/HeeUserMapperTest.java
@@ -1,0 +1,135 @@
+package uk.nhs.hee.tis.usermanagement.mapper;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.transformuk.hee.tis.profile.dto.RoleDTO;
+import com.transformuk.hee.tis.profile.service.dto.HeeUserDTO;
+import com.transformuk.hee.tis.profile.service.dto.UserProgrammeDTO;
+import com.transformuk.hee.tis.profile.service.dto.UserTrustDTO;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Set;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import uk.nhs.hee.tis.usermanagement.DTOs.AuthenticationUserDto;
+import uk.nhs.hee.tis.usermanagement.DTOs.UserDTO;
+
+class HeeUserMapperTest {
+
+  private static final String GMC_ID = "1234567";
+  private static final String FIRST_NAME = "Anthony";
+  private static final String LAST_NAME = "Gilliam";
+  private static final String PHONE_NUMBER = "0123456789";
+  private static final String EMAIL = "anthony.gilliam@dummy.com";
+  private static final Set<String> DBCS = Set.of("DB1", "DB2");
+
+  private static final String SUB = "5e5axxxx-e1xx-4axx-xxxx-96a7f86xxxxx";
+  private static final String PREFERRED_MFA = "SOFTWARE_TOKEN_MFA";
+  private static final List<String> MFA_SETTINGS = Arrays.asList("EMAIL_OTP", "SOFTWARE_TOKEN_MFA");
+
+  private static final String ROLE_ADMIN = "ADMIN";
+  private static final Long TRUST_ID = 100L;
+  private static final Long PROGRAMME_ID = 200L;
+
+  private HeeUserMapper heeUserMapper;
+
+  @BeforeEach
+  void setUp() {
+    heeUserMapper = new HeeUserMapper();
+  }
+
+  @Test
+  void shouldConvertHeeAndAuthUserCorrectly() {
+    // given: HeeUserDTO
+    HeeUserDTO heeUser = new HeeUserDTO();
+    heeUser.setName(EMAIL);
+    heeUser.setFirstName(FIRST_NAME);
+    heeUser.setLastName(LAST_NAME);
+    heeUser.setGmcId(GMC_ID);
+    heeUser.setPhoneNumber(PHONE_NUMBER);
+    heeUser.setEmailAddress(EMAIL);
+    heeUser.setActive(true);
+    heeUser.setDesignatedBodyCodes(DBCS);
+
+    RoleDTO role = new RoleDTO();
+    role.setName(ROLE_ADMIN);
+    heeUser.setRoles(Set.of(role));
+
+    UserTrustDTO trust = new UserTrustDTO();
+    trust.setTrustId(TRUST_ID);
+    heeUser.setAssociatedTrusts(Set.of(trust));
+
+    UserProgrammeDTO programme = new UserProgrammeDTO();
+    programme.setProgrammeId(PROGRAMME_ID);
+    heeUser.setAssociatedProgrammes(Set.of(programme));
+
+    // given: AuthenticationUserDto
+    AuthenticationUserDto authUser = new AuthenticationUserDto();
+    authUser.setId(SUB);
+    authUser.setEnabled(true);
+    authUser.setPreferredMfaSetting(PREFERRED_MFA);
+    authUser.setUserMFASettingList(MFA_SETTINGS);
+
+    // when
+    UserDTO result = heeUserMapper.convert(heeUser, authUser);
+
+    // then: HeeUser mapping
+    assertEquals(EMAIL, result.getName());
+    assertEquals(FIRST_NAME, result.getFirstName());
+    assertEquals(LAST_NAME, result.getLastName());
+    assertEquals(GMC_ID, result.getGmcId());
+    assertEquals(PHONE_NUMBER, result.getPhoneNumber());
+    assertEquals(EMAIL, result.getEmailAddress());
+    assertEquals(DBCS, result.getLocalOffices());
+    assertEquals(ROLE_ADMIN, result.getRoles().iterator().next());
+    assertEquals(TRUST_ID.toString(), result.getAssociatedTrusts().iterator().next());
+    assertEquals(PROGRAMME_ID.toString(), result.getAssociatedProgrammes().iterator().next());
+
+    // then: AuthUser mapping
+    assertEquals(SUB, result.getAuthId());
+    assertTrue(result.isActive());
+    assertEquals(PREFERRED_MFA, result.getPreferredMfaSetting());
+    assertEquals(MFA_SETTINGS, result.getUserMFASettingList());
+  }
+
+  @Test
+  void shouldHandleNullHeeUser() {
+    AuthenticationUserDto authUser = new AuthenticationUserDto();
+    authUser.setId(SUB);
+    authUser.setEnabled(true);
+
+    UserDTO result = heeUserMapper.convert(null, authUser);
+
+    assertEquals(SUB, result.getAuthId());
+    assertTrue(result.isActive());
+  }
+
+  @Test
+  void shouldHandleNullAuthUser() {
+    HeeUserDTO heeUser = new HeeUserDTO();
+    heeUser.setFirstName(FIRST_NAME);
+    heeUser.setActive(true);
+
+    UserDTO result = heeUserMapper.convert(heeUser, null);
+
+    assertEquals(FIRST_NAME, result.getFirstName());
+    assertNull(result.getAuthId());
+    assertTrue(result.isActive());
+  }
+
+  @Test
+  void shouldHandleEmptyCollections() {
+    HeeUserDTO heeUser = new HeeUserDTO();
+    heeUser.setRoles(Set.of());
+    heeUser.setAssociatedTrusts(Set.of());
+    heeUser.setAssociatedProgrammes(Set.of());
+
+    UserDTO result = heeUserMapper.convert(heeUser, null);
+
+    assertTrue(result.getRoles().isEmpty());
+    assertTrue(result.getAssociatedTrusts().isEmpty());
+    assertTrue(result.getAssociatedProgrammes().isEmpty());
+  }
+}

--- a/src/test/java/uk/nhs/hee/tis/usermanagement/resource/UserResourceTest.java
+++ b/src/test/java/uk/nhs/hee/tis/usermanagement/resource/UserResourceTest.java
@@ -5,6 +5,7 @@ import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.stringContainsInOrder;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -361,5 +362,23 @@ class UserResourceTest {
         .andExpect(jsonPath("$.errorCode").value("Internal Server Error"))
         .andExpect(jsonPath("$.errorType").value("Internal Server Error"))
         .andExpect(jsonPath("$.message").value(message));
+  }
+
+  @Test
+  void shouldResetUserMfaSettings() throws Exception {
+    doNothing().when(mockFacade).resetUserMfaSettings("foo");
+
+    mockMvc.perform(post("/api/users/foo/mfa/reset"))
+        .andExpect(status().isOk());
+  }
+
+  @Test
+  void shouldReturnErrorWhenResetUserMfaSettingsFails() throws Exception {
+    UserNotFoundException exception = new UserNotFoundException("foo", "Cognito");
+    doThrow(exception).when(mockFacade).resetUserMfaSettings("foo");
+
+    mockMvc.perform(post("/api/users/foo/mfa/reset"))
+        .andExpect(status().isInternalServerError())
+        .andExpect(jsonPath("$").value(exception.getMessage()));
   }
 }

--- a/src/test/java/uk/nhs/hee/tis/usermanagement/service/CognitoAuthenticationAdminServiceTest.java
+++ b/src/test/java/uk/nhs/hee/tis/usermanagement/service/CognitoAuthenticationAdminServiceTest.java
@@ -341,7 +341,7 @@ class CognitoAuthenticationAdminServiceTest {
     Optional<AuthenticationUserDto> result = service.getUserWithMfaInfo(USERNAME);
     assertTrue(result.isPresent());
     AuthenticationUserDto authenticationUserDto = result.get();
-    assertEquals(MFA_SETTINGS, authenticationUserDto.getUserMFASettingList());
+    assertEquals(MFA_SETTINGS, authenticationUserDto.getUserMfaSettingList());
   }
 
   @Test
@@ -350,7 +350,6 @@ class CognitoAuthenticationAdminServiceTest {
     when(cognitoClient.adminGetUser(any(AdminGetUserRequest.class)))
         .thenThrow(new RuntimeException(errorMessage));
 
-    // Expect exception
     RuntimeException exception = assertThrows(RuntimeException.class, () -> {
       service.getUserWithMfaInfo(USERNAME);
     });

--- a/src/test/java/uk/nhs/hee/tis/usermanagement/service/KeyCloakAdminClientServiceTest.java
+++ b/src/test/java/uk/nhs/hee/tis/usermanagement/service/KeyCloakAdminClientServiceTest.java
@@ -327,4 +327,14 @@ public class KeyCloakAdminClientServiceTest {
   public void getUserAuthEventsNotImplemented() {
     assertThrows(NotImplementedException.class, () -> testObj.getUserAuthEvents("user"));
   }
+
+  @Test
+  public void getUserWithMfaInfoNotImplemented() {
+    assertThrows(NotImplementedException.class, () -> testObj.getUserWithMfaInfo("user"));
+  }
+
+  @Test
+  public void resetUserMfaSettingsNotImplemented() {
+    assertThrows(NotImplementedException.class, () -> testObj.resetUserMfaSettings("user"));
+  }
 }


### PR DESCRIPTION
1) return mfa settings for single user
2) add an endpoint to reset MFA

The Sonar analysis doesn’t look quite right. The test coverage shouldn’t include DTOs, and the code smells analysis doesn’t seem to be based on the new code.

TIS21-7915