### PR TITLE
fix: during MFA resetting, set EMAIL_OTP as preferred method

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
   <groupId>uk.nhs.hee.tis</groupId>
   <artifactId>usermanagement</artifactId>
-  <version>0.1.0</version>
+  <version>0.1.1</version>
   <packaging>jar</packaging>
 
   <name>usermanagement</name>

--- a/src/main/java/uk/nhs/hee/tis/usermanagement/service/CognitoAuthenticationAdminService.java
+++ b/src/main/java/uk/nhs/hee/tis/usermanagement/service/CognitoAuthenticationAdminService.java
@@ -142,6 +142,7 @@ public class CognitoAuthenticationAdminService extends AbstractAuthenticationAdm
         .userPoolId(userPoolId)
         .username(username)
         .softwareTokenMfaSettings(builder -> builder.enabled(false).build())
+        .emailMfaSettings(builder -> builder.enabled(true).preferredMfa(true).build())
         .build();
     try {
       cognitoClient.adminSetUserMFAPreference(request);


### PR DESCRIPTION
This resetting operation is equivalent to `aws cognito-idp admin-set-user-mfa-preference --software-token-mfa-settings Enabled=false --email-mfa-settings Enabled=true,PreferredMfa=true --user-pool-id XXXX --username YYYY`

TIS21-7915